### PR TITLE
Add badges to README, set minimum Python version to 3.7, fix whitespace bug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: [3.7, 3.9]
 
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # JSOM: JSON minus Notation plus Macros
 
+[![Test](https://github.com/saulpw/jsom/actions/workflows/main.yml/badge.svg)](https://github.com/saulpw/jsom/actions?query=workflow%3ATest)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/saulpw/jsom/blob/master/LICENSE.txt)
+
 [Alternate possible names: NOSJ (Nicer Object Syntax for JSON), JSM]
 
 ## A human-readable, -writable, and -diffable format for reasonable JSON

--- a/jsom/encoder.py
+++ b/jsom/encoder.py
@@ -163,7 +163,7 @@ class JsomEncoder:
             else:
                 i += 1
 
-        return '\n'.join((x.start_level-1)*' '+str(x) for x in chonks)
+        return '\n'.join((x.start_level)*' '+str(x) for x in chonks)
 
 
 def chonker(toks):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
         name="jsom",
         version="2022.03.08",
-        python_requires='>=3.6',
+        python_requires='>=3.7',
         py_modules=['jsom'],
         packages=["jsom"],
         entry_points={"console_scripts": ["jsom=jsom.__main__:main"]},


### PR DESCRIPTION
`dataclasses` were first added in Python 3.7.