### PR TITLE
Update formatter

### DIFF
--- a/jsom/__init__.py
+++ b/jsom/__init__.py
@@ -20,11 +20,6 @@ class JsomCoder(JsomEncoder, JsomDecoder):
         if self.options['debug']:
             print(*args, file=sys.stderr, **kwargs)
 
-    def encode(self, obj, formatter=None):
-        if not formatter:
-            formatter = JsomFormatter()
-        return formatter(self.iterencode(obj))
-
 
 JsomEncoderDecoder = JsomCoder
 
@@ -34,5 +29,6 @@ __all__ = [
     "JsomDecoder",
     "JsomEncoder",
     "JsomCoder",
+    "JsomFormatter",
     "deep_match",
 ]

--- a/jsom/encoder.py
+++ b/jsom/encoder.py
@@ -1,4 +1,5 @@
-from .jsom import InnerDict, deep_match, deep_del
+from .jsom import InnerDict, deep_match, deep_del, deep_len
+from .formatter import JsomFormatter
 
 
 class JsomEncoder:
@@ -12,7 +13,7 @@ class JsomEncoder:
             if not isinstance(v, (dict, list))
         }
 
-    def iterencode(self, obj, depth=0, parents=None):
+    def iterencode(self, obj, sort_key=lambda x: 0, depth=0, parents=None):
         ''
         if parents is None:
             parents = []
@@ -36,7 +37,7 @@ class JsomEncoder:
                 if isinstance(m, dict):  # matched with args
                     if m:
                         macro_invocation = ['(', macroname]
-                        args = [self.iterencode(x, depth=depth+1) for x in m.values()]
+                        args = [self.iterencode(x, sort_key, depth=depth+1) for x in m.values()]
                         macro_invocation.extend(x.strip() for y in args for x in y if x.strip())
                         macro_invocation.append(')')
                     else:
@@ -55,8 +56,6 @@ class JsomEncoder:
                     if not obj:
                         break
 
-            # if no macro fully applied, emit rest of dictionary
-
             show_braces = (depth != 0) and (len(macro_invocations) + len(obj) > 1)
 
             if show_braces:
@@ -65,9 +64,9 @@ class JsomEncoder:
             for innards in macro_invocations:
                 yield from innards
 
-            for k, v in obj.items():
+            for k, v in sorted(obj.items(), key=sort_key):
                 yield f'.{k}'
-                yield from self.iterencode(v, depth=depth+1, parents=parents+[obj])
+                yield from self.iterencode(v, sort_key, depth=depth+1, parents=parents+[obj])
 
             if show_braces:
                 yield '}'
@@ -82,7 +81,7 @@ class JsomEncoder:
                 yield '['
 
             for v in obj:
-                yield from self.iterencode(v, depth=depth+1, parents=parents+[obj])
+                yield from self.iterencode(v, sort_key, depth=depth+1, parents=parents+[obj])
 
             if depth > 0:
                 yield ']'
@@ -119,7 +118,29 @@ class JsomEncoder:
     def encode_oneliner(self, obj):
         return self.encode(obj, formatter=' '.join)
 
-    def encode(self, obj, formatter=None):
-        if not formatter:
+    def encode(self, obj, formatter=None, sort_key=None):
+        """Encodes the given object as JSOM using the macros currently
+        registered with this encoder.
+
+        formatter can be set None to disable formatting, 'pretty' for
+        pretty-printing, or to a function that takes an iterable of tokens and
+        inserts whitespace between them to form a string, such as
+        ' '.join (= None), an instance of JsomFormatter for pretty-printing
+        (default options = 'pretty'), or a user-defined pretty-printing
+        function.
+
+        sort_key can be set to None (the default) to emit dict keys in Python's
+        natural order, 'key' to order alphabetically by the keys, 'size' to
+        order by the number of primitive values in the value, or any function
+        taking a key-value pair to be passed to sorted()."""
+        if formatter is None:
             formatter = ' '.join
-        return formatter(self.iterencode(obj))
+        elif formatter == 'pretty':
+            formatter = JsomFormatter()
+        if sort_key is None:
+            sort_key = lambda x: 0
+        elif sort_key == 'key':
+            sort_key = lambda x: x
+        elif sort_key == 'size':
+            sort_key = lambda x: deep_len(x[1])
+        return formatter(self.iterencode(obj, sort_key))

--- a/jsom/formatter.py
+++ b/jsom/formatter.py
@@ -2,7 +2,15 @@ __all__ = ['JsomFormatter']
 
 
 class JsomFormatter:
-    def __init__(self, indent_str='  ', length_limit=80, value_limit=5):
+    def __init__(
+        self,
+        indent_str='  ',
+        length_limit=80,
+        value_limit=5,
+        strip_spaces='',
+        close_on_same_line=False,
+        dedent_last_value=False,
+    ):
         """
         Creates a JSOM formatter using the given configuration.
          - indent_str specifies which indentation character(s) to use.
@@ -13,10 +21,24 @@ class JsomFormatter:
            that will be considered for emitting a group of tokens as a single
            line. Nested tokens will always only be inlined if there are no
            other values in the group.
+         - strip_spaces specifies for which parenthesis types the space
+           immediately after the open paran or immediately before the close
+           paren will be stripped. For example, specifying strip_spaces='[]'
+           will emit lists as [1 2 3] instead of [ 1 2 3 ].
+         - If close_on_same_line is set, the closing paren for multiline
+           groups will be printed immediately after the last enclosed value
+           rather than on a new line.
+         - If dedent_last_value is set, whenever both the current group
+           and the last inner group are wrapped, the latter is not indented.
+           This works best when used in conjunction with dict entries sorted
+           by increasing size.
         """
         self._indent_str = indent_str
         self._length_limit = length_limit
         self._value_limit = value_limit
+        self._strip_spaces = strip_spaces
+        self._close_on_same_line = close_on_same_line
+        self._dedent_last_value = dedent_last_value
 
     @staticmethod
     def _is_open(token):
@@ -42,6 +64,11 @@ class JsomFormatter:
     def _is_spacing(token):
         """Whether a token is merely spacing."""
         return isinstance(token, str) and not token.strip()
+
+    @classmethod
+    def _is_newline(cls, token):
+        """Whether a token is whitespace including a newline."""
+        return cls._is_spacing(token) and '\n' in token
 
     @staticmethod
     def _is_comment(token):
@@ -96,15 +123,24 @@ class JsomFormatter:
 
         return root
 
-    def _should_wrap(self, tokens: list) -> bool:
+    def _should_wrap(self, tokens, is_macro=False) -> bool:
         """Whether the given list of nested tokens should be wrapped. This is
         a completely heuristic thing."""
+
+        # Non-nested tokens should never be wrapped.
+        if not self._is_nested(tokens):
+            return False
 
         # Accumulate the approximate line length (not counting indentation)
         # we'd get if we don't wrap and the number of values in the token list.
         # When either reaches the limit, we decide to wrap.
         length = 0
         values = 0
+
+        # The first "value" in a macro isn't really a macro, it's just its
+        # name.
+        if is_macro:
+            values -= 1
 
         # Never wrap if there are no tokens.
         if not tokens:
@@ -116,8 +152,14 @@ class JsomFormatter:
                 break
             length += len(token)
 
-        # Accumulate length and value count of tokens
+        # Accumulate length and value count of tokens.
         for token in tokens:
+
+            # Ignore open/close parentheses as they are not part of the
+            # contents that will be wrapped. Note that these should only ever
+            # occur at the start or end of a nested token list.
+            if self._is_open(token) or self._is_close(token):
+                continue
 
             # Groups containing @ commands or comments must always be wrapped.
             if self._is_at(token) or self._is_comment(token):
@@ -146,12 +188,25 @@ class JsomFormatter:
         # Did not reach any of the limits, keep on single line.
         return False
 
+    def _strip_whitespace(self):
+        """Strips the whitespace added by default after the previous token.
+        WARNING: be careful to only use this when whitespace between the
+        previous and next token is known to be optional, or if you're about to
+        replace the whitespace with some other kind of whitespace."""
+        if self._output and self._is_spacing(self._output[-1]):
+            self._output.pop()
+
     def _emit_newline(self, count=1):
         """Emit the given amount of newlines with the current indentation
         level. Overrides any previously emitted whitespace."""
-        if self._output and self._is_spacing(self._output[-1]):
-            self._output.pop()
+        self._strip_whitespace()
         self._output.append(count*'\n' + self._indent*self._indent_str)
+
+    def _emit_space(self):
+        """Emit a single space, overriding any previously emitted
+        whitespace."""
+        self._strip_whitespace()
+        self._output.append(' ')
 
     def _emit_token(self, token):
         """Emit the given token, followed by the minimum amount of spacing
@@ -176,25 +231,31 @@ class JsomFormatter:
         if tokens and self._is_open(tokens[0]):
             open_token, *tokens = tokens
 
+        # Macros get some special treatment here and there, because its first
+        # "value" is just the name of the macro rather than an actual value.
+        is_macro = open_token == '('
+
         # Determine whether we should wrap these tokens.
-        wrap = self._should_wrap(tokens)
+        wrap = self._should_wrap(tokens, is_macro)
 
         # Emit open token, if any.
         if open_token is not None:
             self._emit_token(open_token)
+            if open_token in self._strip_spaces:
+                self._strip_whitespace()
 
         # Update indentation level.
         if wrap and open_token is not None:
             self._indent += 1
 
-            # ( is used for macro invocations, where the first token is the
-            # macro. It looks nicer if the macro name is on the same line.
-            if tokens[0] != '(':
+            # It looks nicer if the macro name is on the same line.
+            if not is_macro:
                 self._emit_newline()
 
         # Handle nested tokens.
         in_comment = False
-        for token in tokens:
+        for index, token in enumerate(tokens):
+            last = index == len(tokens) - 1
 
             # Do a hard break all the way back to indentation level 0 before
             # any @ token.
@@ -205,6 +266,10 @@ class JsomFormatter:
             # Do a double newline before the first line comment in a sequence.
             if not in_comment and self._is_comment(token):
                 self._emit_newline(2)
+
+            if last and wrap and self._dedent_last_value and self._should_wrap(token):
+                self._indent -= 1
+                wrap = False
 
             # Emit the token.
             self._emit_token(token)
@@ -223,10 +288,16 @@ class JsomFormatter:
         if wrap and close_token is not None:
             if self._indent > 0:
                 self._indent -= 1
-            self._emit_newline()
+            if self._close_on_same_line:
+                self._emit_space()
+            else:
+                self._emit_newline()
 
         # Emit close token, if any.
         if close_token is not None:
+            if not self._is_newline(self._output[-1]):
+                if close_token in self._strip_spaces:
+                    self._strip_whitespace()
             self._emit_token(close_token)
 
     def __call__(self, tokens) -> str:

--- a/jsom/jsom.py
+++ b/jsom/jsom.py
@@ -108,3 +108,12 @@ def deep_del(a: dict, b: dict):
                         break
         else:
             del a[k]
+
+
+def deep_len(x):
+    'returns the amount of primitive values in a nested structure.'
+    if isinstance(x, dict):
+        return sum(map(deep_len, x.values()))
+    elif isinstance(x, list):
+        return sum(map(deep_len, x))
+    return 1

--- a/tojsom.py
+++ b/tojsom.py
@@ -24,4 +24,4 @@ for fn in sys.argv[1:]:
     elif d:
         out.append(d)
 
-print(j.encode(out))
+print(j.encode(out, 'pretty'))


### PR DESCRIPTION
Added a bunch of options to the formatter and a key sorting option for the encoder, and extended the command line options accordingly.

I think this set of options matches your style most closely: `--order-by-size --close-on-same-line --dedent-last-value --strip-spaces '()'`.

<details><summary>(click to expand example)</summary>

```console
user@host:~$ cat macros.jsom
@macros
.field .selection { .directReference .structField .field ?v .rootReference {} }
.field0 .selection { .directReference .structField {} .rootReference {} }
.varchar_t .varchar { .nullability "NULLABILITY_NULLABLE" .length ?len .typeVariationReference 0 }
.char_t? .fixedChar { .nullability "NULLABILITY_NULLABLE" .length ?len .typeVariationReference 0 }
.char_t .fixedChar { .nullability "NULLABILITY_REQUIRED" .length ?len .typeVariationReference 0 }
.decimal_t .decimal { .nullability "NULLABILITY_NULLABLE" .scale ?scale .precision ?precision .typeVariationReference 0 }
.date_t .date { .nullability "NULLABILITY_NULLABLE" .typeVariationReference 0 }
.int64_t .i64 { .nullability "NULLABILITY_REQUIRED" .typeVariationReference 0 }
.int32_t? .i32 { .nullability "NULLABILITY_NULLABLE" .typeVariationReference 0 }
.nullable < .nullability "NULLABILITY_NULLABLE" >
.required < .nullability "NULLABILITY_REQUIRED" >

.TRUE .literal { .boolean true .nullable false }
.FALSE .literal { .boolean false .nullable false }
.string .literal { .fixedChar ?value .nullable false }
.date .literal { .date ?value .nullable false }

.cast .cast { .type ?type .input ?input }
.bool? .bool { .nullability "NULLABILITY_NULLABLE" .typeVariationReference 0 }
.bool .bool { .nullability "NULLABILITY_REQUIRED" .typeVariationReference 0 }

.extfunc .extensionFunction {
      .extensionUriReference ?uriref
      .functionAnchor ?anchor
      .name ?name
    }

.sort-asc < .sorts [ { .expr ?expr .direction "SORT_DIRECTION_ASC_NULLS_LAST" } ] >
.sort-desc < .sorts [ { .expr ?expr .direction "SORT_DIRECTION_DESC_NULLS_FIRST" } ] >


.common < .common .direct {} >

.func .scalarFunction { .functionReference ?anchor .args ?args .outputType ?outputtype }
user@host:~$ cat plan.json
{
  "extensionUris": [{
    "extensionUriAnchor": 1,
    "uri": "/functions_boolean.yaml"
  }, {
    "extensionUriAnchor": 4,
    "uri": "/functions_arithmetic_decimal.yaml"
  }, {
    "extensionUriAnchor": 3,
    "uri": "/functions_datetime.yaml"
  }, {
    "extensionUriAnchor": 2,
    "uri": "/functions_comparison.yaml"
  }],
  "extensions": [{
    "extensionFunction": {
      "extensionUriReference": 1,
      "functionAnchor": 1,
      "name": "and:bool"
    }
  }, {
    "extensionFunction": {
      "extensionUriReference": 2,
      "functionAnchor": 2,
      "name": "equal:any1_any1"
    }
  }, {
    "extensionFunction": {
      "extensionUriReference": 3,
      "functionAnchor": 3,
      "name": "lt:date_date"
    }
  }, {
    "extensionFunction": {
      "extensionUriReference": 3,
      "functionAnchor": 4,
      "name": "gt:date_date"
    }
  }, {
    "extensionFunction": {
      "extensionUriReference": 4,
      "functionAnchor": 5,
      "name": "multiply:opt_decimal_decimal"
    }
  }, {
    "extensionFunction": {
      "extensionUriReference": 4,
      "functionAnchor": 6,
      "name": "subtract:opt_decimal_decimal"
    }
  }, {
    "extensionFunction": {
      "extensionUriReference": 4,
      "functionAnchor": 7,
      "name": "sum:opt_decimal"
    }
  }],
  "relations": [{
    "root": {
      "input": {
        "fetch": {
          "common": {
            "direct": {
            }
          },
          "input": {
            "sort": {
              "common": {
                "direct": {
                }
              },
              "input": {
                "project": {
                  "common": {
                    "emit": {
                      "outputMapping": [4, 5, 6, 7]
                    }
                  },
                  "input": {
                    "aggregate": {
                      "common": {
                        "direct": {
                        }
                      },
                      "input": {
                        "project": {
                          "common": {
                            "emit": {
                              "outputMapping": [33, 34, 35, 36]
                            }
                          },
                          "input": {
                            "filter": {
                              "common": {
                                "direct": {
                                }
                              },
                              "input": {
                                "join": {
                                  "common": {
                                    "direct": {
                                    }
                                  },
                                  "left": {
                                    "join": {
                                      "common": {
                                        "direct": {
                                        }
                                      },
                                      "left": {
                                        "read": {
                                          "common": {
                                            "direct": {
                                            }
                                          },
                                          "baseSchema": {
                                            "names": ["C_CUSTKEY", "C_NAME", "C_ADDRESS", "C_NATIONKEY", "C_PHONE", "C_ACCTBAL", "C_MKTSEGMENT", "C_COMMENT"],
                                            "struct": {
                                              "types": [{
                                                "i64": {
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_REQUIRED"
                                                }
                                              }, {
                                                "varchar": {
                                                  "length": 25,
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_NULLABLE"
                                                }
                                              }, {
                                                "varchar": {
                                                  "length": 40,
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_NULLABLE"
                                                }
                                              }, {
                                                "i64": {
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_REQUIRED"
                                                }
                                              }, {
                                                "fixedChar": {
                                                  "length": 15,
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_NULLABLE"
                                                }
                                              }, {
                                                "decimal": {
                                                  "scale": 0,
                                                  "precision": 19,
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_NULLABLE"
                                                }
                                              }, {
                                                "fixedChar": {
                                                  "length": 10,
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_NULLABLE"
                                                }
                                              }, {
                                                "varchar": {
                                                  "length": 117,
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_NULLABLE"
                                                }
                                              }],
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_REQUIRED"
                                            }
                                          },
                                          "namedTable": {
                                            "names": ["CUSTOMER"]
                                          }
                                        }
                                      },
                                      "right": {
                                        "read": {
                                          "common": {
                                            "direct": {
                                            }
                                          },
                                          "baseSchema": {
                                            "names": ["O_ORDERKEY", "O_CUSTKEY", "O_ORDERSTATUS", "O_TOTALPRICE", "O_ORDERDATE", "O_ORDERPRIORITY", "O_CLERK", "O_SHIPPRIORITY", "O_COMMENT"],
                                            "struct": {
                                              "types": [{
                                                "i64": {
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_REQUIRED"
                                                }
                                              }, {
                                                "i64": {
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_REQUIRED"
                                                }
                                              }, {
                                                "fixedChar": {
                                                  "length": 1,
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_NULLABLE"
                                                }
                                              }, {
                                                "decimal": {
                                                  "scale": 0,
                                                  "precision": 19,
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_NULLABLE"
                                                }
                                              }, {
                                                "date": {
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_NULLABLE"
                                                }
                                              }, {
                                                "fixedChar": {
                                                  "length": 15,
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_NULLABLE"
                                                }
                                              }, {
                                                "fixedChar": {
                                                  "length": 15,
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_NULLABLE"
                                                }
                                              }, {
                                                "i32": {
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_NULLABLE"
                                                }
                                              }, {
                                                "varchar": {
                                                  "length": 79,
                                                  "typeVariationReference": 0,
                                                  "nullability": "NULLABILITY_NULLABLE"
                                                }
                                              }],
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_REQUIRED"
                                            }
                                          },
                                          "namedTable": {
                                            "names": ["ORDERS"]
                                          }
                                        }
                                      },
                                      "expression": {
                                        "literal": {
                                          "boolean": true,
                                          "nullable": false
                                        }
                                      },
                                      "type": "JOIN_TYPE_INNER"
                                    }
                                  },
                                  "right": {
                                    "read": {
                                      "common": {
                                        "direct": {
                                        }
                                      },
                                      "baseSchema": {
                                        "names": ["L_ORDERKEY", "L_PARTKEY", "L_SUPPKEY", "L_LINENUMBER", "L_QUANTITY", "L_EXTENDEDPRICE", "L_DISCOUNT", "L_TAX", "L_RETURNFLAG", "L_LINESTATUS", "L_SHIPDATE", "L_COMMITDATE", "L_RECEIPTDATE", "L_SHIPINSTRUCT", "L_SHIPMODE", "L_COMMENT"],
                                        "struct": {
                                          "types": [{
                                            "i64": {
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_REQUIRED"
                                            }
                                          }, {
                                            "i64": {
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_REQUIRED"
                                            }
                                          }, {
                                            "i64": {
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_REQUIRED"
                                            }
                                          }, {
                                            "i32": {
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_NULLABLE"
                                            }
                                          }, {
                                            "decimal": {
                                              "scale": 0,
                                              "precision": 19,
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_NULLABLE"
                                            }
                                          }, {
                                            "decimal": {
                                              "scale": 0,
                                              "precision": 19,
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_NULLABLE"
                                            }
                                          }, {
                                            "decimal": {
                                              "scale": 0,
                                              "precision": 19,
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_NULLABLE"
                                            }
                                          }, {
                                            "decimal": {
                                              "scale": 0,
                                              "precision": 19,
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_NULLABLE"
                                            }
                                          }, {
                                            "fixedChar": {
                                              "length": 1,
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_NULLABLE"
                                            }
                                          }, {
                                            "fixedChar": {
                                              "length": 1,
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_NULLABLE"
                                            }
                                          }, {
                                            "date": {
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_NULLABLE"
                                            }
                                          }, {
                                            "date": {
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_NULLABLE"
                                            }
                                          }, {
                                            "date": {
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_NULLABLE"
                                            }
                                          }, {
                                            "fixedChar": {
                                              "length": 25,
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_NULLABLE"
                                            }
                                          }, {
                                            "fixedChar": {
                                              "length": 10,
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_NULLABLE"
                                            }
                                          }, {
                                            "varchar": {
                                              "length": 44,
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_NULLABLE"
                                            }
                                          }],
                                          "typeVariationReference": 0,
                                          "nullability": "NULLABILITY_REQUIRED"
                                        }
                                      },
                                      "namedTable": {
                                        "names": ["LINEITEM"]
                                      }
                                    }
                                  },
                                  "expression": {
                                    "literal": {
                                      "boolean": true,
                                      "nullable": false
                                    }
                                  },
                                  "type": "JOIN_TYPE_INNER"
                                }
                              },
                              "condition": {
                                "scalarFunction": {
                                  "functionReference": 1,
                                  "args": [{
                                    "scalarFunction": {
                                      "functionReference": 2,
                                      "args": [{
                                        "selection": {
                                          "directReference": {
                                            "structField": {
                                              "field": 6
                                            }
                                          },
                                          "rootReference": {
                                          }
                                        }
                                      }, {
                                        "cast": {
                                          "type": {
                                            "fixedChar": {
                                              "length": 10,
                                              "typeVariationReference": 0,
                                              "nullability": "NULLABILITY_REQUIRED"
                                            }
                                          },
                                          "input": {
                                            "literal": {
                                              "fixedChar": "HOUSEHOLD",
                                              "nullable": false
                                            }
                                          }
                                        }
                                      }],
                                      "outputType": {
                                        "bool": {
                                          "typeVariationReference": 0,
                                          "nullability": "NULLABILITY_NULLABLE"
                                        }
                                      }
                                    }
                                  }, {
                                    "scalarFunction": {
                                      "functionReference": 2,
                                      "args": [{
                                        "selection": {
                                          "directReference": {
                                            "structField": {
                                              "field": 0
                                            }
                                          },
                                          "rootReference": {
                                          }
                                        }
                                      }, {
                                        "selection": {
                                          "directReference": {
                                            "structField": {
                                              "field": 9
                                            }
                                          },
                                          "rootReference": {
                                          }
                                        }
                                      }],
                                      "outputType": {
                                        "bool": {
                                          "typeVariationReference": 0,
                                          "nullability": "NULLABILITY_REQUIRED"
                                        }
                                      }
                                    }
                                  }, {
                                    "scalarFunction": {
                                      "functionReference": 2,
                                      "args": [{
                                        "selection": {
                                          "directReference": {
                                            "structField": {
                                              "field": 17
                                            }
                                          },
                                          "rootReference": {
                                          }
                                        }
                                      }, {
                                        "selection": {
                                          "directReference": {
                                            "structField": {
                                              "field": 8
                                            }
                                          },
                                          "rootReference": {
                                          }
                                        }
                                      }],
                                      "outputType": {
                                        "bool": {
                                          "typeVariationReference": 0,
                                          "nullability": "NULLABILITY_REQUIRED"
                                        }
                                      }
                                    }
                                  }, {
                                    "scalarFunction": {
                                      "functionReference": 3,
                                      "args": [{
                                        "selection": {
                                          "directReference": {
                                            "structField": {
                                              "field": 12
                                            }
                                          },
                                          "rootReference": {
                                          }
                                        }
                                      }, {
                                        "literal": {
                                          "date": 9214,
                                          "nullable": false
                                        }
                                      }],
                                      "outputType": {
                                        "bool": {
                                          "typeVariationReference": 0,
                                          "nullability": "NULLABILITY_NULLABLE"
                                        }
                                      }
                                    }
                                  }, {
                                    "scalarFunction": {
                                      "functionReference": 4,
                                      "args": [{
                                        "selection": {
                                          "directReference": {
                                            "structField": {
                                              "field": 27
                                            }
                                          },
                                          "rootReference": {
                                          }
                                        }
                                      }, {
                                        "literal": {
                                          "date": 9214,
                                          "nullable": false
                                        }
                                      }],
                                      "outputType": {
                                        "bool": {
                                          "typeVariationReference": 0,
                                          "nullability": "NULLABILITY_NULLABLE"
                                        }
                                      }
                                    }
                                  }],
                                  "outputType": {
                                    "bool": {
                                      "typeVariationReference": 0,
                                      "nullability": "NULLABILITY_NULLABLE"
                                    }
                                  }
                                }
                              }
                            }
                          },
                          "expressions": [{
                            "selection": {
                              "directReference": {
                                "structField": {
                                  "field": 17
                                }
                              },
                              "rootReference": {
                              }
                            }
                          }, {
                            "selection": {
                              "directReference": {
                                "structField": {
                                  "field": 12
                                }
                              },
                              "rootReference": {
                              }
                            }
                          }, {
                            "selection": {
                              "directReference": {
                                "structField": {
                                  "field": 15
                                }
                              },
                              "rootReference": {
                              }
                            }
                          }, {
                            "scalarFunction": {
                              "functionReference": 5,
                              "args": [{
                                "selection": {
                                  "directReference": {
                                    "structField": {
                                      "field": 22
                                    }
                                  },
                                  "rootReference": {
                                  }
                                }
                              }, {
                                "scalarFunction": {
                                  "functionReference": 6,
                                  "args": [{
                                    "cast": {
                                      "type": {
                                        "decimal": {
                                          "scale": 0,
                                          "precision": 19,
                                          "typeVariationReference": 0,
                                          "nullability": "NULLABILITY_NULLABLE"
                                        }
                                      },
                                      "input": {
                                        "literal": {
                                          "i32": 1,
                                          "nullable": false
                                        }
                                      }
                                    }
                                  }, {
                                    "selection": {
                                      "directReference": {
                                        "structField": {
                                          "field": 23
                                        }
                                      },
                                      "rootReference": {
                                      }
                                    }
                                  }],
                                  "outputType": {
                                    "decimal": {
                                      "scale": 0,
                                      "precision": 19,
                                      "typeVariationReference": 0,
                                      "nullability": "NULLABILITY_NULLABLE"
                                    }
                                  }
                                }
                              }],
                              "outputType": {
                                "decimal": {
                                  "scale": 0,
                                  "precision": 19,
                                  "typeVariationReference": 0,
                                  "nullability": "NULLABILITY_NULLABLE"
                                }
                              }
                            }
                          }]
                        }
                      },
                      "groupings": [{
                        "groupingExpressions": [{
                          "selection": {
                            "directReference": {
                              "structField": {
                                "field": 0
                              }
                            },
                            "rootReference": {
                            }
                          }
                        }, {
                          "selection": {
                            "directReference": {
                              "structField": {
                                "field": 1
                              }
                            },
                            "rootReference": {
                            }
                          }
                        }, {
                          "selection": {
                            "directReference": {
                              "structField": {
                                "field": 2
                              }
                            },
                            "rootReference": {
                            }
                          }
                        }]
                      }, {
                        "groupingExpressions": [{
                          "selection": {
                            "directReference": {
                              "structField": {
                                "field": 0
                              }
                            },
                            "rootReference": {
                            }
                          }
                        }, {
                          "selection": {
                            "directReference": {
                              "structField": {
                                "field": 1
                              }
                            },
                            "rootReference": {
                            }
                          }
                        }, {
                          "selection": {
                            "directReference": {
                              "structField": {
                                "field": 2
                              }
                            },
                            "rootReference": {
                            }
                          }
                        }]
                      }],
                      "measures": [{
                        "measure": {
                          "functionReference": 7,
                          "args": [{
                            "selection": {
                              "directReference": {
                                "structField": {
                                  "field": 3
                                }
                              },
                              "rootReference": {
                              }
                            }
                          }],
                          "sorts": [],
                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                          "outputType": {
                            "decimal": {
                              "scale": 0,
                              "precision": 19,
                              "typeVariationReference": 0,
                              "nullability": "NULLABILITY_NULLABLE"
                            }
                          }
                        }
                      }]
                    }
                  },
                  "expressions": [{
                    "selection": {
                      "directReference": {
                        "structField": {
                          "field": 0
                        }
                      },
                      "rootReference": {
                      }
                    }
                  }, {
                    "selection": {
                      "directReference": {
                        "structField": {
                          "field": 3
                        }
                      },
                      "rootReference": {
                      }
                    }
                  }, {
                    "selection": {
                      "directReference": {
                        "structField": {
                          "field": 1
                        }
                      },
                      "rootReference": {
                      }
                    }
                  }, {
                    "selection": {
                      "directReference": {
                        "structField": {
                          "field": 2
                        }
                      },
                      "rootReference": {
                      }
                    }
                  }]
                }
              },
              "sorts": [{
                "expr": {
                  "selection": {
                    "directReference": {
                      "structField": {
                        "field": 1
                      }
                    },
                    "rootReference": {
                    }
                  }
                },
                "direction": "SORT_DIRECTION_DESC_NULLS_FIRST"
              }, {
                "expr": {
                  "selection": {
                    "directReference": {
                      "structField": {
                        "field": 2
                      }
                    },
                    "rootReference": {
                    }
                  }
                },
                "direction": "SORT_DIRECTION_ASC_NULLS_LAST"
              }]
            }
          },
          "offset": "0",
          "count": "10"
        }
      },
      "names": ["L_ORDERKEY", "REVENUE", "O_ORDERDATE", "O_SHIPPRIORITY"]
    }
  }],
  "expectedTypeUrls": []
}
user@host:~$ `jsom -d macros.jsom -e plan.json -p --order-by-size --close-on-same-line --dedent-last-value --strip-spaces '()'`
{
  .expectedTypeUrls [ ]
  .extensionUris [
    { .extensionUriAnchor 1 .uri "/functions_boolean.yaml" }
    { .extensionUriAnchor 4 .uri "/functions_arithmetic_decimal.yaml" }
    { .extensionUriAnchor 3 .uri "/functions_datetime.yaml" }
    { .extensionUriAnchor 2 .uri "/functions_comparison.yaml" } ]
  .extensions [
    (extfunc 1 1 "and:bool")
    (extfunc 2 2 "equal:any1_any1")
    (extfunc 3 3 "lt:date_date")
    (extfunc 3 4 "gt:date_date")
    (extfunc 4 5 "multiply:opt_decimal_decimal")
    (extfunc 4 6 "subtract:opt_decimal_decimal")
    (extfunc 4 7 "sum:opt_decimal") ]
  .relations [ .root {
    .names [ "L_ORDERKEY" "REVENUE" "O_ORDERDATE" "O_SHIPPRIORITY" ]
    .input .fetch {
    common
    .offset "0"
    .count "10"
    .input .sort {
    (sort-asc (field 2))
    (sort-desc (field 1))
    common
    .input .project {
    .common .emit .outputMapping [ 4 5 6 7 ]
    .expressions [
      (field 0)
      (field 3)
      (field 1)
      (field 2) ]
    .input .aggregate {
    common
    .groupings [
      .groupingExpressions [
        (field 0)
        (field 1)
        (field 2) ]
      .groupingExpressions [
      (field 0)
      (field 1)
      (field 2) ] ]
    .measures [ .measure {
      .sorts [ ]
      .functionReference 7
      .args [ (field 3) ]
      .phase "AGGREGATION_PHASE_INITIAL_TO_RESULT"
      .outputType (decimal_t 0 19) } ]
    .input .project {
    .common .emit .outputMapping [ 33 34 35 36 ]
    .expressions [
      (field 17)
      (field 12)
      (field 15)
      (func
      5
      [
        (field 22)
        (func
        6
        [
          (cast
            (decimal_t 0 19)
            .literal { .i32 1 .nullable false })
          (field 23) ]
        (decimal_t 0 19)) ]
      (decimal_t 0 19)) ]
    .input .filter {
    common
    .condition (func
      1
      [
        (func
          2
          [
            (field 6)
            (cast
            (char_t 10)
            (string "HOUSEHOLD")) ]
          bool?)
        (func
          2
          [
            (field 0)
            (field 9) ]
          bool)
        (func
          2
          [
            (field 17)
            (field 8) ]
          bool)
        (func
          3
          [
            (field 12)
            (date 9214) ]
          bool?)
        (func
        4
        [
          (field 27)
          (date 9214) ]
        bool?) ]
      bool?)
    .input .join {
    common
    .type "JOIN_TYPE_INNER"
    .expression TRUE
    .right .read {
      common
      .namedTable .names [ "LINEITEM" ]
      .baseSchema {
      .names [
        "L_ORDERKEY"
        "L_PARTKEY"
        "L_SUPPKEY"
        "L_LINENUMBER"
        "L_QUANTITY"
        "L_EXTENDEDPRICE"
        "L_DISCOUNT"
        "L_TAX"
        "L_RETURNFLAG"
        "L_LINESTATUS"
        "L_SHIPDATE"
        "L_COMMITDATE"
        "L_RECEIPTDATE"
        "L_SHIPINSTRUCT"
        "L_SHIPMODE"
        "L_COMMENT" ]
      .struct {
      required
      .typeVariationReference 0
      .types [
      int64_t
      int64_t
      int64_t
      int32_t?
      (decimal_t 0 19)
      (decimal_t 0 19)
      (decimal_t 0 19)
      (decimal_t 0 19)
      (char_t? 1)
      (char_t? 1)
      date_t
      date_t
      date_t
      (char_t? 25)
      (char_t? 10)
      (varchar_t 44) ] } } }
    .left .join {
    common
    .type "JOIN_TYPE_INNER"
    .expression TRUE
    .left .read {
      common
      .namedTable .names [ "CUSTOMER" ]
      .baseSchema {
      .names [
        "C_CUSTKEY"
        "C_NAME"
        "C_ADDRESS"
        "C_NATIONKEY"
        "C_PHONE"
        "C_ACCTBAL"
        "C_MKTSEGMENT"
        "C_COMMENT" ]
      .struct {
      required
      .typeVariationReference 0
      .types [
      int64_t
      (varchar_t 25)
      (varchar_t 40)
      int64_t
      (char_t? 15)
      (decimal_t 0 19)
      (char_t? 10)
      (varchar_t 117) ] } } }
    .right .read {
    common
    .namedTable .names [ "ORDERS" ]
    .baseSchema {
    .names [
      "O_ORDERKEY"
      "O_CUSTKEY"
      "O_ORDERSTATUS"
      "O_TOTALPRICE"
      "O_ORDERDATE"
      "O_ORDERPRIORITY"
      "O_CLERK"
      "O_SHIPPRIORITY"
      "O_COMMENT" ]
    .struct {
    required
    .typeVariationReference 0
    .types [
    int64_t
    int64_t
    (char_t? 1)
    (decimal_t 0 19)
    date_t
    (char_t? 15)
    (char_t? 15)
    int32_t?
    (varchar_t 79) ] } } } } } } } } } } } } ] }

```

</details>

Note that I removed the following macros from your list because they mess with the key-value ordering:

```
.inner-join .join { .type "JOIN_TYPE_INNER" .expression ?expr .common .direct {} .left ?left .right ?right }
.common-join .join { .type ?jointype .expression ?expr .common .direct {} .left ?left .right ?right }
.common-input < .common .direct {} .input ?input >
.common-output < .common .emit .outputMapping ?output .input ?input >
```

but otherwise that's the same plan and macro list you were using. I don't think I'd go that crazy with the default macros for Substrait in the validator, though; some of them are pretty specific to this plan. By the way, the outer `{}` is because the command-line app is in fact encoding a list of dicts rather than just that JSON file, it's not a formatter thing.

Note also that this construct

```
(func
  3
  [
    (field 12)
    (date 9214) ]
  bool?)
```

would look a lot nicer if printed like

```
(func 3 [
  (field 12)
  (date 9214) ]
  bool?)
```

or, y'know, just

```
(func 3 [ (field 12) (date 9214) ] bool?)
```

but this is kind of a limitation of the formatter right now. When deciding whether to wrap a parenthesized group it doesn't recursively look into subgroups to not make the whole thing O(depth^2), but just immediately wraps when it finds one and it isn't the only element. I don't think the current indentation logic would get it right either if a non-wrapped value contains multiple values that are eventually wrapped; you'd get something like

```
(a 1 2 3 [
  4
  5
  6
] 7 [
  8
  9
])
```

if it would decide to wrap the lists but not the macro for some reason (if wouldn't here, but the emit_token invocation for the macro doesn't know that).

This is also why it was wrapping those macro calls we were confused about on slack, by the way; it treated the macro name as a value, so if the argument of the macro is a grouped thing it would immediately decide to wrap. The name is now special-cased, so now it does reduce

```
(
  sort-asc
  ( field 2 )
)
```

to 

```
( sort-asc ( field 2 ) )
```

because the inner macro is the only value.

I think I could solve it without O(depth^2) complexity, but I'm pretty sure I'd basically have to rewrite the formatter to work depth-first and handle indentation completely differently.